### PR TITLE
Add ability to set environment variables for an execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,17 @@ buddy-cli pl r [pipeline]
 ```
 Options:
 ```
- -v, --version    Show version
- -h, --help       Show help
- -j, --json       Output json
- -t, --token      The token used to authenticate the request
- -u, --url        The base URL for the app (default: api.buddy.works)
- -w, --workspace  The name of the workspace in which the command is run
- -p, --project    The name of the project in which the command is run
- -r, --revision   The revision from the repository that will be executed in the pipeline
- -c, --comment    The execution comment
- -f, --refresh    Execute from scratch
+ -v, --version      Show version
+ -h, --help         Show help
+ -j, --json         Output json
+ -t, --token        The token used to authenticate the request
+ -u, --url          The base URL for the app (default: api.buddy.works)
+ -w, --workspace    The name of the workspace in which the command is run
+ -p, --project      The name of the project in which the command is run
+ -r, --revision     The revision from the repository that will be executed in the pipeline
+ -c, --comment      The execution comment
+ -f, --refresh      Execute from scratch
+ -e, --environment  Set environment variables for this execution
 ```
 
 #### Retry pipeline

--- a/src/api.js
+++ b/src/api.js
@@ -183,6 +183,14 @@ function Api() {
     }
     if (args.comment) params.comment = args.comment;
     if (args.refresh) params.refresh = true;
+    if (args.environment) {
+      let variables = args.environment;
+      if (!Array.isArray(variables)) variables = [variables];
+      params.variables = variables.map((pair) => {
+        let [key, value] = pair.split(/=(.+)/);
+        return {key, value};
+      });
+    }
     client.post('/workspaces/:workspace/projects/:project/pipelines/:pipeline/executions', {}, args, params, done);
   };
   /**

--- a/src/cmds/pipeline/run.js
+++ b/src/cmds/pipeline/run.js
@@ -60,6 +60,11 @@ module.exports.builder = {
     describe: 'Execute from scratch',
     type: 'boolean',
   },
+  e: {
+    alias: 'environment',
+    describe: 'Set environment variables',
+    type: 'string',
+  },
 };
 
 module.exports.request = (args, done) => api.runPipeline(args, done);


### PR DESCRIPTION
Working through some use cases for the buddy-cli, and the ability to set environment variables for a specific execution seems really handy, and already exists within the API.

This PR adds that functionality, following this format:

```
$ buddy-cli -w WORKSPACE -p PROJECT pl run PIPELINE -e key1=val -e key2=val2
```

I added it to the README as well. Let me know what you think and if there's other changes you'd like to see.